### PR TITLE
refactor(keymap): streamline key definitions and remove corne-specific config

### DIFF
--- a/config/base.keymap
+++ b/config/base.keymap
@@ -18,9 +18,6 @@
 #include "includes/settings.dtsi"
 
 #define MEH LC(LS(LALT))
-#define CUT LS(DEL)
-#define COPY LC(INS)
-#define PASTE LS(INS)
 #define COMPOSE K_CMENU
 
 / {
@@ -62,7 +59,7 @@
 //                      ╰───────┴───────┴────┴───┴───┴───┴───┴───╯            
   _LTX   &kp LG(Q)    &kp LC(W)   &kp LS(LC(TAB))   &kp LC(TAB)   &kp LC(T)                             &kp LBKT    &kp RBKT     &kp LBRC   &kp RBRC   &kp PRCNT   _RTX
   _LMX   &kp LGUI     &kp LALT    &kp LCTRL         &kp LSHFT     &trans                                &kp HASH    &kp EQUAL    &kp LPAR   &kp RPAR   &kp GRAVE   _RMX
-  _LBX   &kp K_UNDO   &kp CUT     &kp COPY          &kp PASTE     &trans               _MBX             &kp CARET   &kp DOLLAR   &kp LT     &kp GT     &kp TILDE   _RBX
+  _LBX   &kp LG(Z)    &kp LG(X)   &kp LG(C)         &kp LG(V)     &trans               _MBX             &kp CARET   &kp DOLLAR   &kp LT     &kp GT     &kp TILDE   _RBX
                                   _LHX              &kp COMPOSE   &trans      &trans   &kp UNDERSCORE   &kp MINUS   &kp PLUS     _RHX                                  
       >;
       sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -1,7 +1,3 @@
 #include "keys/36.h"
-/ {
-    chosen {
-        zmk,matrix_transform = &five_column_transform;
-    };
-};
+
 #include "base.keymap"


### PR DESCRIPTION
Simplifies the keymap file by redefining key combinations directly
using modifier keys instead of custom macros. This change intends
to improve clarity and maintainability of key mappings.

Removes redundant corne-specific configuration, making the setup
more flexible and reducing complexity in the keymap management.

- Updates CUT, COPY, and PASTE to use standard key combinations
- Eliminates corne-specific matrix transformation settings

This refactoring enhances code readability and aims to standardize
keyboard shortcuts, aligning with common user expectations.