### PR TITLE
feat(keymap): add placeholder thumb key definitions

### DIFF
--- a/config/keys/36.h
+++ b/config/keys/36.h
@@ -52,3 +52,15 @@
 #define RH0 33  // right thumb keys
 #define RH1 34
 #define RH2 35
+
+#define _LTX &none
+#define _LMX &none
+#define _LBX &none
+#define _LHX &none
+
+#define _MBX &none
+
+#define _RTX &none
+#define _RMX &none
+#define _RBX &none
+#define _RHX &none


### PR DESCRIPTION
Introduces placeholder definitions for left and right thumb key positions in the keymap configuration. These definitions serve as a scaffold for future key assignments, enhancing flexibility in customizing input layouts.

Changes Made:
- Added placeholder macros for each thumb key for both hands.
  
Relates to future keymap customization initiatives.